### PR TITLE
Restructure for build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ __pycache__
 
 dist/
 *.egg-info
+
+tmp*
+
+*.html

--- a/README.md
+++ b/README.md
@@ -13,84 +13,21 @@ You can install the package from github:
 pip install git+https://github.com/ADBond/splinkclickhouse.git@v0.2.3
 ```
 
-## Using
 
-### ChDB
-
-Import the relevant api:
 
 ```python
-from splinkclickhouse import ChDBAPI
-```
 
 See [getting started script](./scripts/getting_started_chdb.py) for example of use:
 
-```sh
-uv run python scripts/getting_started_chdb.py
 ```
 
-### Clickhouse instance
 
-Import the relevant api:
 
 ```python
-from splinkclickhouse import ClickhouseAPI
+
+
 ```
 
-You can run a local instance in docker with provided docker-compose file:
-
-```sh
-docker-compose -f scripts/docker-compose.yaml up
-```
-
-See [getting started script](./scripts/getting_started_clickhouse.py) for example of use:
-
-```sh
-uv run python scripts/getting_started_clickhouse.py
-```
-
-## Dev setup
-
-Get dependencies
-
-```sh
-uv sync
-```
-
-Update dev dependencies
-
-```sh
-uv lock
-```
-
-Check package (with `ruff` and `mypy`)
-
-```sh
-./scripts/check_package.sh
-```
-
-Run all pytest tests
-
-```sh
-uv run python -m pytest -vx tests
-```
-
-You can run just the tests with `chdb` (for instance if you do not have clickhouse), or just `clickhouse`, by passing the `-m` flag
-
-```sh
-uv run python -m pytest -vxm chdb tests
-# or the clickhouse tests:
-uv run python -m pytest -vxm clickhouse tests
-```
-
-For clickhouse tests you will need to have docker container running.
-
-Run test scripts
-
-```sh
-uv run python scripts/getting_started_chdb.py
-uv run python scripts/getting_started_clickhouse.py
-```
 
 ## Known issues
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Basic [Clickhouse](https://clickhouse.com/docs/en/intro) support for use as a backend with the data-linkage and deduplication package [Splink](https://moj-analytical-services.github.io/splink/).
 
-Supports in-process [chDB](https://clickhouse.com/docs/en/chdb) version or a clickhouse instance connected via [clickhouse connect](https://clickhouse.com/docs/en/integrations/python).
+Supports in-process [chDB](https://clickhouse.com/docs/en/chdb) version or a clickhouse server connected via [clickhouse connect](https://clickhouse.com/docs/en/integrations/python).
 
 ## Installation
 
@@ -13,23 +13,105 @@ You can install the package from github:
 pip install git+https://github.com/ADBond/splinkclickhouse.git@v0.2.3
 ```
 
+## Use
 
+### `chDB`
 
+Import `ChDBAPI`, which accepts a connection from `chdb.api`:
 ```python
+import splink.comparison_library as cl
+from chdb import dbapi
+from splink import Linker, SettingsCreator, block_on, splink_datasets
 
-See [getting started script](./scripts/getting_started_chdb.py) for example of use:
+from splinkclickhouse import ChDBAPI
 
+con = dbapi.connect()
+db_api = ChDBAPI(con)
+
+df = splink_datasets.fake_1000
+
+settings = SettingsCreator(
+    link_type="dedupe_only",
+    comparisons=[
+        cl.NameComparison("first_name"),
+        cl.JaroAtThresholds("surname"),
+        cl.DateOfBirthComparison(
+            "dob",
+            input_is_string=True,
+        ),
+        cl.DamerauLevenshteinAtThresholds("city").configure(
+            term_frequency_adjustments=True
+        ),
+        cl.EmailComparison("email"),
+    ],
+    blocking_rules_to_generate_predictions=[
+        block_on("first_name", "dob"),
+        block_on("surname"),
+    ],
+)
+
+linker = Linker(df, settings, db_api=db_api)
 ```
 
+See [Splink documentation](https://moj-analytical-services.github.io/splink/) for use of the `Linker`.
 
+### Clickhouse server
 
+Import `ClickhouseAPI`, which accepts a `clickhouse_connect` client, configured with attributes relevant for your connection:
 ```python
+import clickhouse_connect
+import splink.comparison_library as cl
+from splink import Linker, SettingsCreator, block_on, splink_datasets
 
+from splinkclickhouse import ClickhouseAPI
 
+df = splink_datasets.fake_1000
+
+conn_atts = {
+    "host": "localhost",
+    "port": 8123,
+    "username": "splinkognito",
+    "password": "splink123!",
+}
+
+db_name = "__temp_splink_db"
+
+default_client = clickhouse_connect.get_client(**conn_atts)
+default_client.command(f"CREATE DATABASE IF NOT EXISTS {db_name}")
+client = clickhouse_connect.get_client(
+    **conn_atts,
+    database=db_name,
+)
+
+db_api = ClickhouseAPI(client)
+
+# can have at most one tf-adjusted comparison, see caveats below
+settings = SettingsCreator(
+    link_type="dedupe_only",
+    comparisons=[
+        cl.JaroWinklerAtThresholds("first_name"),
+        cl.JaroAtThresholds("surname"),
+        cl.DateOfBirthComparison(
+            "dob",
+            input_is_string=True,
+        ),
+        cl.DamerauLevenshteinAtThresholds("city").configure(
+            term_frequency_adjustments=True
+        ),
+        cl.JaccardAtThresholds("email"),
+    ],
+    blocking_rules_to_generate_predictions=[
+        block_on("first_name", "dob"),
+        block_on("surname"),
+    ],
+)
+
+linker = Linker(df, settings, db_api=db_api)
 ```
 
+See [Splink documentation](https://moj-analytical-services.github.io/splink/) for use of the `Linker`.
 
-## Known issues
+## Known issues / caveats
 
 ### Datetime parsing
 
@@ -39,11 +121,11 @@ The basic `Date` format cannot handle dates before the epoch (1970-01-01), which
 The parsing function `parseDateTime` (and variants) which support providing custom formats return a `DateTime`, which also has the above limited range.
 In `splinkclickhouse` we use the function `parseDateTime64BestEffortOrNull` so that we can use the extended-range `DateTime64` data type, which supports dates back to 1900-01-01, but does not allow custom date formats. Currently no `DateTime64` equivalent of `parseDateTime` exists.
 
-If you require different behaviour (for instance if you have an unusual date format and know that you do not need dates outside of the `DateTime` range) you will either need to derive a new column manually, or construct the relevant SQL expression manually.
+If you require different behaviour (for instance if you have an unusual date format and know that you do not need dates outside of the `DateTime` range) you will either need to derive a new column in your source data, or construct the relevant SQL expression manually.
 
 There is not currently a way in Clickhouse to deal directly with date values before 1900 - if you require such values you will have to manually process these to a different type, and construct the relevant SQL logic.
 
-### `NULL` values in `chDB`
+### `NULL` values in `chdb`
 
 When passing data into `chdb` from pandas or pyarrow tables, `NULL` values in `String` columns are converted into empty strings, instead of remaining `NULL`.
 
@@ -52,7 +134,7 @@ For now this is not handled within the package. You can workaround the issue by 
 ```python
 import splink.comparison_level as cl
 
-fn_comparison = cl.DamerauLevenshteinAtThresholds("NULLIF(first_name, '')")
+first_name_comparison = cl.DamerauLevenshteinAtThresholds("NULLIF(first_name, '')")
 ```
 
 ### Term-frequency adjustments
@@ -65,4 +147,4 @@ This also applies to `ChDBAPI` but _only in `debug_mode`_. With `debug_mode` off
 
 `ClickhouseAPI` will allow registration of pandas dataframes, by inferring the types of columns. It currently only does this for string and integer columns, and will always make them `Nullable`.
 
-If you require other data types, or more fine-grained control, it is recommended to import the data into Clickhouse yourself, and then pass the table name (as a string) instead.
+If you require other data types, or more fine-grained control, it is recommended to import the data into Clickhouse yourself, and then pass the table name (as a string) to the `Linker` instead.

--- a/dev.md
+++ b/dev.md
@@ -1,0 +1,80 @@
+# Dev guide
+
+## Using
+
+### ChDB
+
+Import the relevant api:
+
+```python
+from splinkclickhouse import ChDBAPI
+```
+
+See [getting started script](./scripts/getting_started_chdb.py) for example of use:
+
+```sh
+uv run python scripts/getting_started_chdb.py
+```
+
+### Clickhouse instance
+
+Import the relevant api:
+
+```python
+from splinkclickhouse import ClickhouseAPI
+```
+
+You can run a local instance in docker with provided docker-compose file:
+
+```sh
+docker-compose -f scripts/docker-compose.yaml up
+```
+
+See [getting started script](./scripts/getting_started_clickhouse.py) for example of use:
+
+```sh
+uv run python scripts/getting_started_clickhouse.py
+```
+
+## Dev setup
+
+Get dependencies
+
+```sh
+uv sync
+```
+
+Update dev dependencies
+
+```sh
+uv lock
+```
+
+Check package (with `ruff` and `mypy`)
+
+```sh
+./scripts/check_package.sh
+```
+
+Run all pytest tests
+
+```sh
+uv run python -m pytest -vx tests
+```
+
+You can run just the tests with `chdb` (for instance if you do not have clickhouse), or just `clickhouse`, by passing the `-m` flag
+
+```sh
+uv run python -m pytest -vxm chdb tests
+# or the clickhouse tests:
+uv run python -m pytest -vxm clickhouse tests
+```
+
+For clickhouse tests you will need to have docker container running.
+
+Run test scripts
+
+```sh
+uv run python scripts/getting_started_chdb.py
+uv run python scripts/getting_started_clickhouse.py
+```

--- a/dev.md
+++ b/dev.md
@@ -78,3 +78,17 @@ Run test scripts
 uv run python scripts/getting_started_chdb.py
 uv run python scripts/getting_started_clickhouse.py
 ```
+
+## Build
+
+Build package to `dist/`
+
+```sh
+uv build --package splinkclickhouse
+```
+
+Inspect package contents:
+
+```sh
+mkdir -p tmp && tar -xzvf dist/splinkclickhouse-0.2.3.tar.gz -C tmp/
+```

--- a/dev.md
+++ b/dev.md
@@ -44,7 +44,7 @@ Get dependencies
 uv sync
 ```
 
-Update dev dependencies
+Update dev dependencies (although this happens automatically)
 
 ```sh
 uv lock
@@ -90,5 +90,16 @@ uv build --package splinkclickhouse
 Inspect package contents:
 
 ```sh
+# replace version as appropriate
 mkdir -p tmp && tar -xzvf dist/splinkclickhouse-0.2.3.tar.gz -C tmp/
 ```
+
+### Manual publish
+
+Set `TWINE_PASSWORD` as an appropriate API token. This is to TestPyPI - remove option for the real thing.
+
+```sh
+TWINE_USERNAME=__token__ uvx twine upload -r testpypi dist/*
+```
+
+See [twine docs](https://twine.readthedocs.io/en/stable/) for more info.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,16 @@ dev-dependencies = [
 ]
 package = true
 
+[tool.hatch.build.targets.sdist]
+# opt-in to build
+include = [
+    "splinkclickhouse/*",
+    "LICENSE",
+    "README.md",
+    "CHANGELOG.md",
+    "pyproject.toml"
+]
+
 [tool.ruff]
 line-length = 88
 lint.select = [

--- a/uv.lock
+++ b/uv.lock
@@ -787,7 +787,7 @@ wheels = [
 
 [[package]]
 name = "splinkclickhouse"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "chdb" },


### PR DESCRIPTION
Fiddle with README, split dev guide into a separate file, and opt-in files for build