### PR TITLE
Make `chdb` an optional dependency

### DIFF
--- a/.github/workflows/check-install-no-chdb.yaml
+++ b/.github/workflows/check-install-no-chdb.yaml
@@ -1,0 +1,30 @@
+name: Check package runs without chdb
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "splink/**"
+      - "tests/**"
+      - "pyproject.toml"
+
+jobs:
+  check-install:
+    runs-on: ubuntu-latest
+    name: Check package imports without `chdb` installed
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup uv
+        id: setup-uv
+        uses: astral-sh/setup-uv@v2
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+          cache-suffix: "chdb-less"
+
+      - name: Install Python 3.9
+        run: uv python install 3.9
+
+      - name: Check package imports if we don't have dev dependencies
+        run: uv run --no-dev --isolated python -c "import splinkclickhouse"

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ dist/
 tmp*
 
 *.html
+
+*.csv
+*.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- `chdb` is now an optional dependency, requiring opt-in installation for use of `ChDBAPI` [#28](https://github.com/ADBond/splinkclickhouse/pull/28).
+
 ## [0.2.5] - 2024-09-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,21 +15,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Added support for Splink >= 4.0.2, dropped support for 4.0.0, 4.0.1 [#26](https://github.com/ADBond/splinkclickhouse/pull/26)
+- Added support for Splink >= 4.0.2, dropped support for 4.0.0, 4.0.1 [#26](https://github.com/ADBond/splinkclickhouse/pull/26).
 
 ## [0.2.4] - 2024-09-19
 
 ## Added
 
-- Extended `ClickhouseAPI` pandas table registration to support float columns [#24](https://github.com/ADBond/splinkclickhouse/pull/24)
-- Added Clickhouse-specific library comparisons/levels - `cll_ch.DistanceInKMLevel`, `cl_ch.DistanceInKMAtThresholds`, and `cl_ch.ExactMatchAtSubstringSizes` [#24](https://github.com/ADBond/splinkclickhouse/pull/24)
+- Extended `ClickhouseAPI` pandas table registration to support float columns [#24](https://github.com/ADBond/splinkclickhouse/pull/24).
+- Added Clickhouse-specific library comparisons/levels - `cll_ch.DistanceInKMLevel`, `cl_ch.DistanceInKMAtThresholds`, and `cl_ch.ExactMatchAtSubstringSizes` [#24](https://github.com/ADBond/splinkclickhouse/pull/24).
 
 ## [0.2.3] - 2024-09-16
 
 ### Changed
 
-- Dropped support for python 3.8 [#20](https://github.com/ADBond/splinkclickhouse/pull/20)
-- Removed `numpy`requirements [#20](https://github.com/ADBond/splinkclickhouse/pull/20)
+- Dropped support for python 3.8 [#20](https://github.com/ADBond/splinkclickhouse/pull/20).
+- Removed `numpy`requirements [#20](https://github.com/ADBond/splinkclickhouse/pull/20).
 
 ## [0.2.2] - 2024-09-12
 

--- a/README.md
+++ b/README.md
@@ -2,64 +2,29 @@
 
 Basic [Clickhouse](https://clickhouse.com/docs/en/intro) support for use as a backend with the data-linkage and deduplication package [Splink](https://moj-analytical-services.github.io/splink/).
 
-Supports in-process [chDB](https://clickhouse.com/docs/en/chdb) version or a clickhouse server connected via [clickhouse connect](https://clickhouse.com/docs/en/integrations/python).
+Supports clickhouse server connected via [clickhouse connect](https://clickhouse.com/docs/en/integrations/python).
+
+Also supports in-process [chDB](https://clickhouse.com/docs/en/chdb) version if installed with the `chdb` extras.
 
 ## Installation
 
 Install from `PyPI` using `pip`:
 
 ```sh
+# just installs the Clickhouse server dependencies
 pip install splinkclickhouse
+# or to install with support for chdb:
+pip install splinkclickhouse[chdb]
 ```
 
 Alternatively you can install the package from github:
 
 ```sh
-pip install git+https://github.com/ADBond/splinkclickhouse.git@v0.2.5
 # Replace with any version you want, or specify a branch after '@'
+pip install git+https://github.com/ADBond/splinkclickhouse.git@v0.2.5
 ```
 
 ## Use
-
-### `chDB`
-
-Import `ChDBAPI`, which accepts a connection from `chdb.api`:
-```python
-import splink.comparison_library as cl
-from chdb import dbapi
-from splink import Linker, SettingsCreator, block_on, splink_datasets
-
-from splinkclickhouse import ChDBAPI
-
-con = dbapi.connect()
-db_api = ChDBAPI(con)
-
-df = splink_datasets.fake_1000
-
-settings = SettingsCreator(
-    link_type="dedupe_only",
-    comparisons=[
-        cl.NameComparison("first_name"),
-        cl.JaroAtThresholds("surname"),
-        cl.DateOfBirthComparison(
-            "dob",
-            input_is_string=True,
-        ),
-        cl.DamerauLevenshteinAtThresholds("city").configure(
-            term_frequency_adjustments=True
-        ),
-        cl.EmailComparison("email"),
-    ],
-    blocking_rules_to_generate_predictions=[
-        block_on("first_name", "dob"),
-        block_on("surname"),
-    ],
-)
-
-linker = Linker(df, settings, db_api=db_api)
-```
-
-See [Splink documentation](https://moj-analytical-services.github.io/splink/) for use of the `Linker`.
 
 ### Clickhouse server
 
@@ -105,6 +70,49 @@ settings = SettingsCreator(
             term_frequency_adjustments=True
         ),
         cl.JaccardAtThresholds("email"),
+    ],
+    blocking_rules_to_generate_predictions=[
+        block_on("first_name", "dob"),
+        block_on("surname"),
+    ],
+)
+
+linker = Linker(df, settings, db_api=db_api)
+```
+
+See [Splink documentation](https://moj-analytical-services.github.io/splink/) for use of the `Linker`.
+
+### `chDB`
+
+To use `chdb` as a Splink backend you must install the `chdb` package.
+This is automatically installed if you install with the `chdb` extras (`pip install splinkclickhouse[chdb]`).
+
+Import `ChDBAPI`, which accepts a connection from `chdb.api`:
+```python
+import splink.comparison_library as cl
+from chdb import dbapi
+from splink import Linker, SettingsCreator, block_on, splink_datasets
+
+from splinkclickhouse import ChDBAPI
+
+con = dbapi.connect()
+db_api = ChDBAPI(con)
+
+df = splink_datasets.fake_1000
+
+settings = SettingsCreator(
+    link_type="dedupe_only",
+    comparisons=[
+        cl.NameComparison("first_name"),
+        cl.JaroAtThresholds("surname"),
+        cl.DateOfBirthComparison(
+            "dob",
+            input_is_string=True,
+        ),
+        cl.DamerauLevenshteinAtThresholds("city").configure(
+            term_frequency_adjustments=True
+        ),
+        cl.EmailComparison("email"),
     ],
     blocking_rules_to_generate_predictions=[
         block_on("first_name", "dob"),

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Alternatively you can install the package from github:
 pip install git+https://github.com/ADBond/splinkclickhouse.git@v0.2.5
 ```
 
+While the package is in early development there will may be breaking changes in new versions without warning, although these _should_ only occur in new minor versions.
+Nevertheless if you depend on this package it is recommended to pin a version to avoid any disruption this may cause.
+
 ## Use
 
 ### Clickhouse server
@@ -184,6 +187,13 @@ settings = SettingsCreator(
     ],
 )
 ```
+
+## Support
+
+If you have difficulties with the package you can [open an issue](https://github.com/ADBond/splinkclickhouse/issues).
+You may also [suggest changes by opening a PR](https://github.com/ADBond/splinkclickhouse/pulls), although it may be best to discuss in an issue beforehand.
+
+This package is 'unofficial', in that it is not directly supported by the Splink team. Maintenance / improvements will be done on a 'best effort' basis where resources allow.
 
 ## Known issues / caveats
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,12 @@ readme = "README.md"
 requires-python = ">=3.9,<4.0"
 dependencies = [
     "splink >= 4.0.2",
-    "chdb >= 2.0.1",
     "clickhouse_connect >= 0.7.0",
+]
+
+[project.optional-dependencies]
+chdb = [
+    "chdb >= 2.0.1",
 ]
 
 [build-system]
@@ -20,7 +24,10 @@ build-backend = "hatchling.build"
 dev-dependencies = [
     "ruff == 0.6.4",
     "mypy == 1.11.2",
-    "pytest == 8.3.3"
+    "pytest == 8.3.3",
+    # probably not ideal having this doubled here,
+    # but saves having to pass --all_extras for 'uv run'
+    "chdb >= 2.0.1",
 ]
 package = true
 

--- a/splinkclickhouse/__init__.py
+++ b/splinkclickhouse/__init__.py
@@ -1,6 +1,25 @@
-from .chdb.database_api import ChDBAPI
+from typing import Any
+
 from .clickhouse.database_api import ClickhouseAPI
 
 __version__ = "0.2.5"
+
+
+# Use getarr to make the error appear at the point of use
+def __getattr__(name: str) -> Any:
+    try:
+        if name == "ChDBAPI":
+            from .chdb.database_api import ChDBAPI
+
+            return ChDBAPI
+    except ImportError as err:
+        if name == "ChDBAPI":
+            raise ImportError(
+                f"'{name}' cannot be imported because its dependencies are not "
+                "installed. To get these please install with the 'chdb' extras: "
+                "`pip install splinkclickhouse[chdb]`."
+            ) from err
+    raise ImportError(f"cannot import name '{name}' from splinkclickhouse") from None
+
 
 __all__ = ["ChDBAPI", "ClickhouseAPI"]

--- a/uv.lock
+++ b/uv.lock
@@ -812,13 +812,18 @@ name = "splinkclickhouse"
 version = "0.2.5"
 source = { editable = "." }
 dependencies = [
-    { name = "chdb" },
     { name = "clickhouse-connect" },
     { name = "splink" },
 ]
 
+[package.optional-dependencies]
+chdb = [
+    { name = "chdb" },
+]
+
 [package.dev-dependencies]
 dev = [
+    { name = "chdb" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
@@ -826,13 +831,14 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "chdb", specifier = ">=2.0.1" },
+    { name = "chdb", marker = "extra == 'chdb'", specifier = ">=2.0.1" },
     { name = "clickhouse-connect", specifier = ">=0.7.0" },
     { name = "splink", specifier = ">=4.0.2" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "chdb", specifier = ">=2.0.1" },
     { name = "mypy", specifier = "==1.11.2" },
     { name = "pytest", specifier = "==8.3.3" },
     { name = "ruff", specifier = "==0.6.4" },


### PR DESCRIPTION
This allows installation of the package without the `chdb` version. Using `chdb` is now opt-in.