### PR TITLE
Restore larger debug test

### DIFF
--- a/tests/test_debug_mode.py
+++ b/tests/test_debug_mode.py
@@ -42,7 +42,6 @@ def test_predict(api_info, fake_1000, fake_1000_settings_factory, debug_mode):
 
 
 # all-in-one workflow
-@mark.skip("Until upstream clustering+debug fix comes through")
 @mark.parametrize("debug_mode", [False, True])
 def test_full_basic_run(api_info, fake_1000, fake_1000_settings_factory, debug_mode):
     db_api = api_info["db_api_factory"]()


### PR DESCRIPTION
Restore test skipped in #37 due to an upstream issue, now fixed in [Splink#2470](https://github.com/moj-analytical-services/splink/pull/2470) and available as of 4.0.6