### PR TITLE
Workaround chdb KeyError issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Table registration in `chdb` now works for pandas tables whose indexes do not have a `0` entry [#49](https://github.com/ADBond/splinkclickhouse/pull/49).
+
 ## [0.3.3] - 2024-12-05
 
 ### Added

--- a/splinkclickhouse/chdb/database_api.py
+++ b/splinkclickhouse/chdb/database_api.py
@@ -36,6 +36,14 @@ class ChDBAPI(DatabaseAPI[None]):
         elif isinstance(input, list):
             input = pd.DataFrame.from_records(input)
 
+        # chdb currently needs pandas indices to start at 0
+        # see https://github.com/chdb-io/chdb/issues/282
+        # reset the index if not the case, but otherwise leave alone
+        # TODO: remove this workaround once chdb issue is resolved
+        try:
+            input[0]
+        except KeyError:
+            input = input.reset_index()
         cursor = self._get_cursor()
         sql = (
             f"CREATE OR REPLACE TABLE {self._db_schema}.{table_name} "


### PR DESCRIPTION
Should circumvent #40 for the time being, until a fix is available in `chdb`.