### PR TITLE
Correct CI trigger paths

### DIFF
--- a/.github/workflows/check-install-no-chdb.yaml
+++ b/.github/workflows/check-install-no-chdb.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     paths:
-      - "splink/**"
+      - "splinkclickhouse/**"
       - "tests/**"
       - "pyproject.toml"
 

--- a/.github/workflows/test-chdb.yaml
+++ b/.github/workflows/test-chdb.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     paths:
-      - "splink/**"
+      - "splinkclickhouse/**"
       - "tests/**"
       - "pyproject.toml"
 

--- a/.github/workflows/test-clickhouse.yaml
+++ b/.github/workflows/test-clickhouse.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     paths:
-      - "splink/**"
+      - "splinkclickhouse/**"
       - "tests/**"
       - "pyproject.toml"
 

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     paths:
-      - "splink/**"
+      - "splinkclickhouse/**"
       - "tests/**"
       - "pyproject.toml"
 


### PR DESCRIPTION
Several workflows mistakenly had paths on `splink/` instead of `splinkclickhouse` so that changes not touching tests or `pyproject.toml` wouldn't trigger them (e.g. #49).