### PR TITLE
Run tests on `main`

### DIFF
--- a/.github/workflows/test-clickhouse.yaml
+++ b/.github/workflows/test-clickhouse.yaml
@@ -1,5 +1,10 @@
 name: Run tests
 on:
+  # run on main as comparison for coverage
+  # also doesn't hurt to check main is ship-shaped
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
For comparison coverage report, but also as additional checking (lest an outdated branch miss something, or we have any indeterminacy as in #40).